### PR TITLE
Implement WAI Window Splitter guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Resizable split pane layouts for React applications 🖖
 - Flexible hook-based API that works with any styling method
 - Built with modern CSS, a grid-based layout and custom properties
 - Works with any amount of panes in a vertical or horizontal layout
+- Built following the [Window Splitter](https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/) pattern for accessibility and keyboard controls
 
 ![react-resplit](https://user-images.githubusercontent.com/9557798/209449017-e648a053-f0de-49b1-bc8f-d56b4ddcf5db.gif)
 _Example of a code editor built with `react-resplit`_
@@ -65,6 +66,27 @@ As a basic example, you could provide a `className` prop to the splitter element
   height: 100%;
   background: #ccc;
 }
+```
+
+### Accessibility
+
+Resplit has been implemented using guidence from the [Window Splitter](https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/) pattern.
+
+In addition to built-in accessibility considerations, you should also ensure that splitters are correctly labelled.
+
+If the primary pane has a visible label, the `aria-labelledby` attribute can be used.
+
+```tsx
+<div {...getPaneProps(0)}>
+  <h2 id="pane-1-label">Pane 1</h2>
+</div>
+<div aria-labelledby="pane-1-label" {...getSplitterProps(1)} />
+```
+
+Alternatively, if the pane does not have a visible label, the `aria-label` attribute can be used.
+
+```tsx
+<div aria-label="Pane 1" {...getSplitterProps(1)} />
 ```
 
 ## API

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -30,10 +30,13 @@ export interface SplitterOptions {
 }
 
 export interface SplitterProps {
-  style: CSSProperties;
+  role: 'separator';
+  tabIndex: 0;
   'data-resplit-order': number;
   'data-resplit-active': boolean;
+  style: CSSProperties;
   onMouseDown: () => void;
+  onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
 }
 
 export interface GetSplitterProps {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,6 @@
 import { CSSProperties, LegacyRef, ReactNode } from 'react';
 
-export type DataAttrKeys = 'resizing' | 'collapsed';
+export type Direction = 'horizontal' | 'vertical';
 
 export interface PaneOptions {
   initialSize?: `${number}fr`;
@@ -31,6 +31,7 @@ export interface SplitterOptions {
 
 export interface SplitterProps {
   role: 'separator';
+  'aria-orientation': Direction;
   tabIndex: 0;
   'data-resplit-order': number;
   'data-resplit-active': boolean;
@@ -50,7 +51,7 @@ export interface ResplitMethods {
 }
 
 export interface ResplitOptions {
-  direction: 'horizontal' | 'vertical';
+  direction: Direction;
 }
 
 export interface PaneChild extends PaneOptions {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -31,8 +31,11 @@ export interface SplitterOptions {
 
 export interface SplitterProps {
   role: 'separator';
-  'aria-orientation': Direction;
   tabIndex: 0;
+  'aria-orientation': Direction;
+  'aria-valuemin': number;
+  'aria-valuemax': number;
+  'aria-valuenow': number;
   'data-resplit-order': number;
   'data-resplit-active': boolean;
   style: CSSProperties;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -19,6 +19,7 @@ export interface GetContainerProps {
 export interface PaneProps {
   'data-resplit-order': number;
   'data-resplit-collapsed': boolean;
+  id: string;
 }
 
 export interface GetPaneProps {
@@ -36,6 +37,7 @@ export interface SplitterProps {
   'aria-valuemin': number;
   'aria-valuemax': number;
   'aria-valuenow': number;
+  'aria-controls': string;
   'data-resplit-order': number;
   'data-resplit-active': boolean;
   style: CSSProperties;

--- a/lib/useResplit.ts
+++ b/lib/useResplit.ts
@@ -26,8 +26,15 @@ export const useResplit = ({ direction }: ResplitOptions): ResplitMethods => {
     return childSize?.includes('fr') ? convertFrToNumber(childSize) : convertPxToNumber(childSize);
   };
 
-  const setChildSize = (order: Order, size: string) =>
+  const setChildSize = (order: Order, size: string) => {
     containerRef.current?.style.setProperty(`--resplit-${order}`, size);
+    const child = children[order];
+
+    if (child.type === 'pane') {
+      const paneSplitter = getChildElement(Number(order) + 1);
+      paneSplitter?.setAttribute('aria-valuenow', String(convertFrToNumber(size).toFixed(2)));
+    }
+  };
 
   const getPaneCollapsed = (order: Order) => getChildElement(order)?.getAttribute('data-resplit-collapsed') === 'true';
 
@@ -278,8 +285,11 @@ export const useResplit = ({ direction }: ResplitOptions): ResplitMethods => {
     // Return splitter props
     return {
       role: 'separator',
-      'aria-orientation': direction,
       tabIndex: 0,
+      'aria-orientation': direction,
+      'aria-valuemin': 0,
+      'aria-valuemax': 1,
+      'aria-valuenow': 1,
       'data-resplit-order': order,
       'data-resplit-active': false,
       style: { cursor: CURSOR_BY_DIRECTION[direction] },

--- a/lib/useResplit.ts
+++ b/lib/useResplit.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useId, useLayoutEffect, useRef, useState } from 'react';
 import { CURSOR_BY_DIRECTION, SPLITTER_DEFAULT_SIZE, GRID_TEMPLATE_BY_DIRECTION, PANE_DEFAULT_MIN_SIZE } from './const';
 import {
   ResplitOptions,
@@ -16,6 +16,7 @@ export const useResplit = ({ direction }: ResplitOptions): ResplitMethods => {
   const [children, setChildren] = useState<ChildrenState>({});
   const containerRef = useRef<HTMLDivElement>();
   const activeSplitterOrder = useRef<number | null>(null);
+  const id = useId();
 
   const getChildElement = (order: Order) =>
     containerRef.current?.querySelector(`:scope > [data-resplit-order="${order}"]`);
@@ -267,6 +268,7 @@ export const useResplit = ({ direction }: ResplitOptions): ResplitMethods => {
     return {
       'data-resplit-order': order,
       'data-resplit-collapsed': false,
+      id: `resplit-${id}-${order}`,
     };
   };
 
@@ -291,6 +293,7 @@ export const useResplit = ({ direction }: ResplitOptions): ResplitMethods => {
       'aria-valuemin': 0,
       'aria-valuemax': 1,
       'aria-valuenow': 1,
+      'aria-controls': `resplit-${id}-${order - 1}`,
       'data-resplit-order': order,
       'data-resplit-active': false,
       style: { cursor: CURSOR_BY_DIRECTION[direction] },

--- a/lib/useResplit.ts
+++ b/lib/useResplit.ts
@@ -278,6 +278,7 @@ export const useResplit = ({ direction }: ResplitOptions): ResplitMethods => {
     // Return splitter props
     return {
       role: 'separator',
+      'aria-orientation': direction,
       tabIndex: 0,
       'data-resplit-order': order,
       'data-resplit-active': false,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ const examples = [
 ];
 
 function App() {
-  const [example, setExample] = useState(examples[0]);
+  const [example, setExample] = useState(examples[1]);
 
   return (
     <div className="flex flex-col h-screen text-white bg-zinc-800">

--- a/src/examples/CodeEditor.tsx
+++ b/src/examples/CodeEditor.tsx
@@ -104,7 +104,7 @@ export const CodeEditorExample = () => {
       }}
       customSetup={{
         dependencies: {
-          'react-resplit': '0.0.1',
+          'react-resplit': '0.0.2',
         },
       }}
       theme="dark"

--- a/src/examples/CodeEditor.tsx
+++ b/src/examples/CodeEditor.tsx
@@ -10,7 +10,7 @@ import {
 } from '@codesandbox/sandpack-react';
 
 const SPLITTER_CLASSES =
-  'relative w-full h-full bg-zinc-600 before:absolute before:inset-0 before:bg-blue-600 before:z-10 before:bg-blue-700 before:opacity-0 hover:before:opacity-100 before:transition-opacity before:duration-100 before:ease-in-out data-[resplit-active=true]:before:opacity-100';
+  'relative w-full h-full bg-zinc-600 before:absolute before:inset-0 before:bg-blue-600 before:z-10 before:bg-blue-700 before:opacity-0 hover:before:opacity-100 before:transition-opacity before:duration-100 before:ease-in-out data-[resplit-active=true]:before:opacity-100 focus-visible:before:opacity-100 outline-none';
 
 const HORIZONTAL_SPLITTER_CLASSES = 'before:w-[7px] before:-left-[3px]';
 
@@ -68,7 +68,11 @@ const styleCode = `body {
 }
 `;
 
-const PaneHeader = ({ children }: { children: React.ReactNode }) => <h3 className="px-4 py-3">{children}</h3>;
+const PaneHeader = ({ children, id }: { children: React.ReactNode; id?: string }) => (
+  <h3 className="px-4 py-3" id={id}>
+    {children}
+  </h3>
+);
 
 const PreviewPane = () => {
   const resplitMethods = useResplit({ direction: 'vertical' });
@@ -76,11 +80,12 @@ const PreviewPane = () => {
   return (
     <div className="h-full" {...getContainerProps()}>
       <div {...getPaneProps(0, { initialSize: '0.7fr' })} className="flex flex-col bg-zinc-800">
-        <PaneHeader>Preview</PaneHeader>
+        <PaneHeader id="preview-pane">Preview</PaneHeader>
         <SandpackPreview className="flex-1" />
       </div>
       <div
         {...getSplitterProps(1, { size: '1px' })}
+        aria-labelledby="preview-pane"
         className={[SPLITTER_CLASSES, VERTICAL_SPLITTER_CLASSES].join(' ')}
       />
       <div {...getPaneProps(2, { initialSize: '0.3fr' })} className="flex flex-col bg-zinc-800">
@@ -127,24 +132,26 @@ export const CodeEditorExample = () => {
         </div>
         <div {...getContainerProps()} className="flex-1 font-mono text-sm">
           <div {...getPaneProps(0, { initialSize: '0.15fr', minSize: '0.1fr' })} className="bg-zinc-800">
-            <PaneHeader>Files</PaneHeader>
+            <PaneHeader id="files-pane">Files</PaneHeader>
             <SandpackFileExplorer autoHiddenFiles className="py-0" />
           </div>
           <div
             {...getSplitterProps(1, { size: '1px' })}
+            aria-labelledby="files-pane"
             className={[SPLITTER_CLASSES, HORIZONTAL_SPLITTER_CLASSES].join(' ')}
           />
           <div
             {...getPaneProps(2, { initialSize: '0.45fr', minSize: '0.1fr' })}
             className="flex flex-col bg-zinc-800 overflow-hidden"
           >
-            <PaneHeader>Code</PaneHeader>
+            <PaneHeader id="code-pane">Code</PaneHeader>
             <div className="flex-1 overflow-auto -mt-4 -ml-1 data-[resplit-resizing=true]:opacity-5">
               <SandpackCodeEditor showTabs={false} style={{ height: '100%' }} />
             </div>
           </div>
           <div
             {...getSplitterProps(3, { size: '1px' })}
+            aria-labelledby="code-pane"
             className={[SPLITTER_CLASSES, HORIZONTAL_SPLITTER_CLASSES].join(' ')}
           />
           <div {...getPaneProps(4, { initialSize: '0.4fr', minSize: '0.1fr' })}>


### PR DESCRIPTION
Fixes #1 

- [x] Left Arrow: Moves a vertical splitter to the left.
- [x] Right Arrow: Moves a vertical splitter to the right.
- [x] Up Arrow: Moves a horizontal splitter up.
- [x] Down Arrow: Moves a horizontal splitter down.
- [x] Home (Optional): Moves splitter to the position that gives the primary pane its smallest allowed size. This may completely collapse the primary pane.
- [x] End (Optional): Moves splitter to the position that gives the primary pane its largest allowed size. This may completely collapse the secondary pane.
- [x] Enter: If the primary pane is not collapsed, collapses the pane. If the pane is collapsed, restores the splitter to its previous position.
- [ ] ~~F6 (Optional): Cycle through window panes.~~ Not going to implement this recommendation for now as it is optional and overwriting function keys seems a contentious issue.
- [x] The element that serves as the focusable splitter has role [separator](https://w3c.github.io/aria/#separator).
- [x] The separator element has the [aria-valuenow](https://w3c.github.io/aria/#aria-valuenow) property set to a decimal value representing the current position of the separator.
- [x] The separator element has the [aria-valuemin](https://w3c.github.io/aria/#aria-valuemin) property set to a decimal value that represents the position where the primary pane has its minimum size. This is typically 0.
- [x] The separator element has the [aria-valuemax](https://w3c.github.io/aria/#aria-valuemax) property set to a decimal value that represents the position where the primary pane has its maximum size. This is typically 100.
- [x] ~~If the primary pane has a visible label, it is referenced by [aria-labelledby](https://w3c.github.io/aria/#aria-labelledby) on the separator element. Otherwise, the separator element has a label provided by [aria-label](https://w3c.github.io/aria/#aria-label).~~ Added an example the demo app and README, as these attributes can be set when implemented.
- [x] The separator element has [aria-controls](https://w3c.github.io/aria/#aria-controls) referring to the primary pane.