### PR TITLE
Resize callbacks, new setPaneSizes and getPaneCollapsed methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ The `useResplit` hook returns the methods needed to register the container, pane
 | `getPaneProps`      | `(order: number, options?: PaneOptions) => PaneProps`         |
 | `getSplitterProps`  | `(order: number, options?: SplitterOptions) => SplitterProps` |
 | `getHandleProps`    | `(order: number) => HandleProps`                              |
+| `setPaneSize`       | `(paneSizes: FrValue[]) => void`                              |
+| `getPaneCollapsed`  | `(order: number) => boolean`                                  |
 
 ### getContainerProps `() => ContainerProps`
 
@@ -135,10 +137,13 @@ Given an order as the first argument, returns the props for the pane element.
 
 An optional second argument, used to configure the initial size of the pane as well the minimum size.
 
-| Name          | Type          | Default                               | Description                                                              |
-| ------------- | ------------- | ------------------------------------- | ------------------------------------------------------------------------ |
-| `initialSize` | `${number}fr` | `[available space]/[number of panes]` | Set the initial size of the pane as a fractional unit (fr)               |
-| `minSize`     | `${number}fr` | `"0fr"`                               | Set the minimum size of the pane as a fractional (fr) or pixel (px) unit |
+| Name            | Type                           | Default                               | Description                                                               |
+| --------------- | ------------------------------ | ------------------------------------- | ------------------------------------------------------------------------- |
+| `initialSize`   | `${number}fr`                  | `[available space]/[number of panes]` | Set the initial size of the pane as a fractional unit (fr)                |
+| `minSize`       | `${number}fr` \| `${number}px` | `"0fr"`                               | Set the minimum size of the pane as a fractional (fr) or pixel (px) unit  |
+| `onResizeStart` | `() => void`                   |                                       | Callback function that is called when the pane starts being resized.      |
+| `onResize`      | `(size: FrValue) => void`      |                                       | Callback function that is called when the pane is actively being resized. |
+| `onResizeEnd`   | `(size: FrValue) => void`      |                                       | Callback function that is called when the pane is actively being resized. |
 
 #### PaneProps `object`
 
@@ -193,3 +198,43 @@ Properties needed for the handle element.
 | ------------- | --------------------- | ----------------------------------- |
 | `style`       | `React.CSSProperties` | Style object for the handle element |
 | `onMouseDown` | `() => void`          | Mousedown event handler             |
+
+### setPaneSize `(paneSizes: FrValue[]) => void`
+
+Get the collapsed state of a pane.
+
+Specify the size of each pane as a fractional unit (fr). The number of values should match the number of panes.
+
+```tsx
+setPaneSize(['0.6fr', '0.4fr']);
+```
+
+### getPaneCollapsed `(order: number) => boolean`
+
+Get the collapsed state of a pane.
+
+**Note**: The returned value will not update on every render and should be used in a callback e.g. used in combination with a pane's `onResize` callback.
+
+```tsx
+import { useResplit } from 'react-resplit';
+
+function App() {
+  const { getContainerProps, getSplitterProps, getPaneProps, getPaneCollapsed } = useResplit({
+    direction: 'horizontal',
+  });
+
+  const handleResize = () => {
+    if (isPaneCollapsed(2)) {
+      // Do something
+    }
+  };
+
+  return (
+    <div {...getContainerProps()}>
+      <div {...getPaneProps(0, { initialSize: '0.5fr' })}>Pane 1</div>
+      <div {...getSplitterProps(1, { size: '10px' })} />
+      <div {...getPaneProps(2, { initialSize: '0.5fr', onResize: handleResize })}>Pane 2</div>
+    </div>
+  );
+}
+```

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,7 +2,7 @@ import { CSSProperties, LegacyRef, ReactNode } from 'react';
 
 export type Direction = 'horizontal' | 'vertical';
 
-export type Order = number | string;
+export type Order = number;
 
 export type PxValue = `${number}px`;
 
@@ -60,6 +60,23 @@ export interface ResplitMethods {
    * @returns Handle props object {@link HandleProps}
    */
   getHandleProps: (order: number) => HandleProps;
+  /**
+   * Specify the size of each pane as a fractional unit (fr).
+   * The number of values should match the number of panes.
+   *
+   * @param paneSizes - An array of fractional unit (fr) values. {@link FrValue}
+   *
+   * @example ['0.25fr', '0.25fr', '0.5fr']
+   */
+  setPaneSizes: (paneSizes: FrValue[]) => void;
+  /**
+   * Get the collapsed state of a pane.
+   *
+   * @param order - The order of the pane. {@link Order}
+   *
+   * @returns A boolean indicating if the pane is collapsed or not.
+   */
+  getPaneCollapsed: (order: number) => boolean;
 }
 
 /**
@@ -96,6 +113,22 @@ export interface PaneOptions {
    * @defaultValue '0fr'
    */
   minSize?: PxValue | FrValue;
+  /**
+   * Callback function that is called when the pane starts being resized.
+   */
+  onResizeStart?: () => void;
+  /**
+   * Callback function that is called when the pane is finished being resized.
+   *
+   * @param size - The new size of the pane. {@link FrValue}
+   */
+  onResizeEnd?: (size: FrValue) => void;
+  /**
+   * Callback function that is called when the pane is actively being resized.
+   *
+   * @param size - The new size of the pane. {@link FrValue}
+   */
+  onResize?: (size: FrValue) => void;
 }
 
 /**

--- a/src/examples/CodeEditor.tsx
+++ b/src/examples/CodeEditor.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import * as resplit from 'resplit';
-const { useResplit } = resplit;
+import React, { useState } from 'react';
+import { useResplit } from 'resplit';
 import {
   SandpackProvider,
   SandpackCodeEditor,
@@ -14,7 +13,7 @@ const SPLITTER_CLASSES =
 
 const HORIZONTAL_SPLITTER_CLASSES = 'before:w-[7px] before:-left-[3px]';
 
-const VERTICAL_SPLITTER_CLASSES = 'before:h-[7px] before:-top-[3px]';
+// const VERTICAL_SPLITTER_CLASSES = 'before:h-[7px] before:-top-[3px]';
 
 const appCode = `import { useResplit } from 'react-resplit';
 import './style.css';
@@ -76,42 +75,70 @@ const PaneHeader = ({ children, id }: { children: React.ReactNode; id?: string }
 
 const PreviewPane = () => {
   const resplitMethods = useResplit({ direction: 'vertical' });
-  const { getContainerProps, getSplitterProps, getPaneProps, getHandleProps } = resplitMethods;
+  const { getContainerProps, getSplitterProps, getPaneProps, setPaneSizes, getPaneCollapsed } = resplitMethods;
   const [tab, setTab] = React.useState<'console' | 'problems'>('console');
+  const [collapsed, setCollapsed] = useState(false);
+
+  const handleResize = () => {
+    if (getPaneCollapsed(2)) {
+      setCollapsed(true);
+    } else {
+      setCollapsed(false);
+    }
+  };
 
   return (
     <div className="h-full" {...getContainerProps()}>
-      <div {...getPaneProps(0, { initialSize: '0.7fr' })} className="flex flex-col bg-zinc-800">
-        <PaneHeader id="preview-pane">Preview</PaneHeader>
+      <div {...getPaneProps(0, { initialSize: '0.7fr' })} className="relative flex flex-col bg-zinc-800">
+        <PaneHeader>Preview</PaneHeader>
         <SandpackPreview className="flex-1" />
       </div>
+
+      <div {...getSplitterProps(1, { size: '48px' })}>
+        <PaneHeader>
+          <button
+            className={tab === 'console' ? 'underline' : ''}
+            onClick={() => setTab('console')}
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            Console
+          </button>
+          <button
+            className={tab === 'problems' ? 'underline' : ''}
+            onClick={() => setTab('problems')}
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            Problems
+          </button>
+          <button
+            className={`flex items-center justify-center h-6 w-6 ml-auto hover:bg-zinc-700 ${
+              collapsed ? 'transform rotate-180' : ''
+            }`}
+            onMouseDown={(e) => {
+              e.stopPropagation();
+            }}
+            onClick={() => {
+              setPaneSizes(collapsed ? ['0.4fr', '0.6fr'] : ['1fr', '0fr']);
+              setCollapsed(!collapsed);
+            }}
+          >
+            <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M3.13523 6.15803C3.3241 5.95657 3.64052 5.94637 3.84197 6.13523L7.5 9.56464L11.158 6.13523C11.3595 5.94637 11.6759 5.95657 11.8648 6.15803C12.0536 6.35949 12.0434 6.67591 11.842 6.86477L7.84197 10.6148C7.64964 10.7951 7.35036 10.7951 7.15803 10.6148L3.15803 6.86477C2.95657 6.67591 2.94637 6.35949 3.13523 6.15803Z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </PaneHeader>
+      </div>
+
       <div
-        {...getSplitterProps(1, { size: '1px' })}
-        aria-labelledby="preview-pane"
-        className={[SPLITTER_CLASSES, VERTICAL_SPLITTER_CLASSES].join(' ')}
-      />
-      <div
-        {...getPaneProps(2, { initialSize: '0.3fr', minSize: '44px' })}
+        {...getPaneProps(2, {
+          initialSize: '0.3fr',
+          onResize: handleResize,
+        })}
         className="relative z-10 flex flex-col bg-zinc-800"
       >
-        <div {...getHandleProps(1)}>
-          <PaneHeader>
-            <button
-              className={tab === 'console' ? 'underline' : ''}
-              onClick={() => setTab('console')}
-              onMouseDown={(e) => e.stopPropagation()}
-            >
-              Console
-            </button>
-            <button
-              className={tab === 'problems' ? 'underline' : ''}
-              onClick={() => setTab('problems')}
-              onMouseDown={(e) => e.stopPropagation()}
-            >
-              Problems
-            </button>
-          </PaneHeader>
-        </div>
         <SandpackConsole showHeader={false} className="flex-1 overflow-auto px-2" />
       </div>
     </div>


### PR DESCRIPTION
Adds `setPaneSize` and `getPaneCollapsed` methods as well as `resize` callbacks for panes.

Fixes #7


Allows us to do size-aware behaviour in a UI like so:

https://github.com/KenanYusuf/react-resplit/assets/9557798/3e07a4c4-68ba-4aef-b01b-66eb01f6050f

