### PR TITLE
Add asChild prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Resizable split pane layouts for React applications 🖖
 - Works with any amount of panes in a vertical or horizontal layout
 - Built following the [Window Splitter](https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/) pattern for accessibility and keyboard controls
 
-
-
 https://github.com/KenanYusuf/react-resplit/assets/9557798/d47ef278-bcb1-4c2b-99e6-7a9f99943f96
 
 _Example of a code editor built with `react-resplit`_
@@ -102,12 +100,13 @@ All of the resplit components extend the `React.HTMLAttributes<HTMLDivElement>` 
 
 The root component of a resplit layout. Provides context to all child components.
 
-| Prop        | Type                         | Default        | Description            |
-| ----------- | ---------------------------- | -------------- | ---------------------- |
-| `direction` | `"horizontal" \| "vertical"` | `"horizontal"` | Direction of the panes |
-| `children`  | `ReactNode`                  |                | Child elements         |
-| `className` | `string`                     |                | Class name             |
-| `style`     | `CSSProperties`              |                | Style object           |
+| Prop        | Type                         | Default        | Description                           |
+| ----------- | ---------------------------- | -------------- | ------------------------------------- |
+| `direction` | `"horizontal" \| "vertical"` | `"horizontal"` | Direction of the panes                |
+| `asChild`   | `boolean`                    | `false`        | Merges props onto the immediate child |
+| `children`  | `ReactNode`                  |                | Child elements                        |
+| `className` | `string`                     |                | Class name                            |
+| `style`     | `CSSProperties`              |                | Style object                          |
 
 ### Pane `(ResplitPaneProps)`
 
@@ -120,6 +119,7 @@ A pane is a container that can be resized.
 | `onResizeStart` | `() => void`                   |                                       | Callback function that is called when the pane starts being resized.      |
 | `onResize`      | `(size: FrValue) => void`      |                                       | Callback function that is called when the pane is actively being resized. |
 | `onResizeEnd`   | `(size: FrValue) => void`      |                                       | Callback function that is called when the pane is actively being resized. |
+| `asChild`       | `boolean`                      | `false`                               | Merges props onto the immediate child                                     |
 | `children`      | `ReactNode`                    |                                       | Child elements                                                            |
 | `className`     | `string`                       |                                       | Class name                                                                |
 | `style`         | `CSSProperties`                |                                       | Style object                                                              |
@@ -131,6 +131,7 @@ A splitter is a draggable element that can be used to resize panes.
 | Name        | Type            | Default  | Description                                  |
 | ----------- | --------------- | -------- | -------------------------------------------- |
 | `size`      | `${number}px`   | `"10px"` | Set the size of the splitter as a pixel unit |
+| `asChild`   | `boolean`       | `false`  | Merges props onto the immediate child        |
 | `children`  | `ReactNode`     |          | Child elements                               |
 | `className` | `string`        |          | Class name                                   |
 | `style`     | `CSSProperties` |          | Style object                                 |

--- a/lib/Pane.tsx
+++ b/lib/Pane.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, HTMLAttributes, forwardRef } from 'react';
+import { Slot } from '@radix-ui/react-slot';
 
 import { useRootContext } from './RootContext';
 import { PANE_DEFAULT_MIN_SIZE } from './const';
@@ -51,6 +52,22 @@ export type ResplitPaneProps = HTMLAttributes<HTMLDivElement> &
      * The content of the pane.
      */
     children?: ReactNode;
+    /**
+     * Merges props onto the immediate child.
+     *
+     * @defaultValue false
+     *
+     * @example
+     *
+     * ```tsx
+     * <ResplitPane order={0} asChild>
+     *   <aside style={{ backgroundColor: 'red' }}>
+     *     ...
+     *   </aside>
+     * </ResplitPane>
+     * ```
+     */
+    asChild?: boolean;
   };
 
 /**
@@ -71,6 +88,7 @@ export const ResplitPane = forwardRef<HTMLDivElement, ResplitPaneProps>(function
     order,
     minSize = PANE_DEFAULT_MIN_SIZE,
     initialSize,
+    asChild = false,
     onResize,
     onResizeStart,
     onResizeEnd,
@@ -78,6 +96,7 @@ export const ResplitPane = forwardRef<HTMLDivElement, ResplitPaneProps>(function
   },
   ref,
 ) {
+  const Comp = asChild ? Slot : 'div';
   const { id, registerPane } = useRootContext();
 
   useIsomorphicLayoutEffect(() => {
@@ -91,7 +110,7 @@ export const ResplitPane = forwardRef<HTMLDivElement, ResplitPaneProps>(function
   }, []);
 
   return (
-    <div
+    <Comp
       id={`resplit-${id}-${order}`}
       data-resplit-order={order}
       data-resplit-collapsed={false}
@@ -99,6 +118,6 @@ export const ResplitPane = forwardRef<HTMLDivElement, ResplitPaneProps>(function
       {...rest}
     >
       {children}
-    </div>
+    </Comp>
   );
 });

--- a/lib/Root.tsx
+++ b/lib/Root.tsx
@@ -1,4 +1,5 @@
 import { HTMLAttributes, ReactNode, forwardRef, useId, useRef, useState } from 'react';
+import { Slot } from '@radix-ui/react-slot';
 
 import { ResplitContext } from './ResplitContext';
 import { RootContext } from './RootContext';
@@ -65,6 +66,22 @@ export type ResplitRootProps = ResplitOptions &
      * The children of the ResplitRoot component.
      */
     children: ReactNode;
+    /**
+     * Merges props onto the immediate child.
+     *
+     * @defaultValue false
+     *
+     * @example
+     *
+     * ```tsx
+     * <ResplitRoot asChild>
+     *   <main style={{ backgroundColor: 'red' }}>
+     *     ...
+     *   </main>
+     * </ResplitRoot>
+     * ```
+     */
+    asChild?: boolean;
   };
 
 /**
@@ -80,10 +97,11 @@ export type ResplitRootProps = ResplitOptions &
  * ```
  */
 export const ResplitRoot = forwardRef<HTMLDivElement, ResplitRootProps>(function Root(
-  { direction = 'horizontal', children: reactChildren, style, ...rest },
+  { direction = 'horizontal', children: reactChildren, style, asChild = false, ...rest },
   forwardedRef,
 ) {
   const id = useId();
+  const Comp = asChild ? Slot : 'div';
   const activeSplitterOrder = useRef<number | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const [children, setChildren] = useState<ChildrenState>({});
@@ -409,7 +427,7 @@ export const ResplitRoot = forwardRef<HTMLDivElement, ResplitRootProps>(function
           setPaneSizes,
         }}
       >
-        <div
+        <Comp
           ref={mergeRefs([rootRef, forwardedRef])}
           data-resplit-direction={direction}
           data-resplit-resizing={false}
@@ -428,7 +446,7 @@ export const ResplitRoot = forwardRef<HTMLDivElement, ResplitRootProps>(function
           {...rest}
         >
           {reactChildren}
-        </div>
+        </Comp>
       </ResplitContext.Provider>
     </RootContext.Provider>
   );

--- a/lib/Splitter.tsx
+++ b/lib/Splitter.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, HTMLAttributes, forwardRef } from 'react';
+import { Slot } from '@radix-ui/react-slot';
 
 import { useRootContext } from './RootContext';
 import { CURSOR_BY_DIRECTION, SPLITTER_DEFAULT_SIZE } from './const';
@@ -27,6 +28,22 @@ export type ResplitSplitterProps = HTMLAttributes<HTMLDivElement> &
      * The content of the splitter.
      */
     children?: ReactNode;
+    /**
+     * Merges props onto the immediate child.
+     *
+     * @defaultValue false
+     *
+     * @example
+     *
+     * ```tsx
+     * <ResplitSplitter asChild>
+     *   <div style={{ backgroundColor: 'red' }}>
+     *     ...
+     *   </div>
+     * </ResplitSplitter>
+     * ```
+     */
+    asChild?: boolean;
   };
 
 /**
@@ -40,9 +57,10 @@ export type ResplitSplitterProps = HTMLAttributes<HTMLDivElement> &
  * ```
  */
 export const ResplitSplitter = forwardRef<HTMLDivElement, ResplitSplitterProps>(function Splitter(
-  { children, order, size = SPLITTER_DEFAULT_SIZE, ...rest },
+  { children, order, size = SPLITTER_DEFAULT_SIZE, asChild = false, ...rest },
   ref,
 ) {
+  const Comp = asChild ? Slot : 'div';
   const { id, direction, registerSplitter, handleSplitterMouseDown, handleSplitterKeyDown } =
     useRootContext();
 
@@ -52,7 +70,7 @@ export const ResplitSplitter = forwardRef<HTMLDivElement, ResplitSplitterProps>(
 
   return (
     // eslint-disable-next-line jsx-a11y/role-supports-aria-props, jsx-a11y/no-noninteractive-element-interactions
-    <div
+    <Comp
       role="separator"
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={0}
@@ -70,6 +88,6 @@ export const ResplitSplitter = forwardRef<HTMLDivElement, ResplitSplitterProps>(
       {...rest}
     >
       {children}
-    </div>
+    </Comp>
   );
 });

--- a/package.json
+++ b/package.json
@@ -77,5 +77,8 @@
     "typescript": "^4.6.3",
     "vite": "^4.0.5",
     "vite-plugin-dts": "^1.7.1"
+  },
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,6 +190,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.13.10":
+  version "7.23.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.2.tgz#062b0ac103261d68a966c4c7baf2ae3e62ec3885"
+  integrity sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.18.10", "@babel/template@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -868,6 +875,21 @@
     picocolors "^1.0.0"
     tiny-glob "^0.2.9"
     tslib "^2.4.0"
+
+"@radix-ui/react-compose-refs@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz#7ed868b66946aa6030e580b1ffca386dd4d21989"
+  integrity sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-slot@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.2.tgz#a9ff4423eade67f501ffb32ec22064bc9d3099ab"
+  integrity sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
 
 "@react-hook/intersection-observer@^3.1.1":
   version "3.1.1"
@@ -3034,6 +3056,11 @@ regenerator-runtime@^0.13.11:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
+  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
 
 regexp.prototype.flags@^1.4.3:
   version "1.4.3"


### PR DESCRIPTION
Adds an asChild prop to the different resplit elements to allow more flexibility around the rendered HTML.

Fixes #20 