### PR TITLE
Collapsible panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,17 +112,19 @@ The root component of a resplit layout. Provides context to all child components
 
 A pane is a container that can be resized.
 
-| Prop            | Type                           | Default                               | Description                                                               |
-| --------------- | ------------------------------ | ------------------------------------- | ------------------------------------------------------------------------- |
-| `initialSize`   | `${number}fr`                  | `[available space]/[number of panes]` | Set the initial size of the pane as a fractional unit (fr)                |
-| `minSize`       | `${number}fr` \| `${number}px` | `"0fr"`                               | Set the minimum size of the pane as a fractional (fr) or pixel (px) unit  |
-| `onResizeStart` | `() => void`                   |                                       | Callback function that is called when the pane starts being resized.      |
-| `onResize`      | `(size: FrValue) => void`      |                                       | Callback function that is called when the pane is actively being resized. |
-| `onResizeEnd`   | `(size: FrValue) => void`      |                                       | Callback function that is called when the pane is actively being resized. |
-| `asChild`       | `boolean`                      | `false`                               | Merges props onto the immediate child                                     |
-| `children`      | `ReactNode`                    |                                       | Child elements                                                            |
-| `className`     | `string`                       |                                       | Class name                                                                |
-| `style`         | `CSSProperties`                |                                       | Style object                                                              |
+| Prop            | Type                           | Default                               | Description                                                                |
+| --------------- | ------------------------------ | ------------------------------------- | -------------------------------------------------------------------------- |
+| `initialSize`   | `${number}fr`                  | `[available space]/[number of panes]` | Set the initial size of the pane as a fractional unit (fr)                 |
+| `minSize`       | `${number}fr` \| `${number}px` | `"0fr"`                               | Set the minimum size of the pane as a fractional (fr) or pixel (px) unit   |
+| `collapsible`   | `boolean`                      | `false`                               | Whether the pane can be collapsed below its minimum size                   |
+| `collapsedSize` | `${number}fr` \| `${number}px` | `"0fr"`                               | Set the collapsed size of the pane as a fractional (fr) or pixel (px) unit |
+| `onResizeStart` | `() => void`                   |                                       | Callback function that is called when the pane starts being resized.       |
+| `onResize`      | `(size: FrValue) => void`      |                                       | Callback function that is called when the pane is actively being resized.  |
+| `onResizeEnd`   | `(size: FrValue) => void`      |                                       | Callback function that is called when the pane is actively being resized.  |
+| `asChild`       | `boolean`                      | `false`                               | Merges props onto the immediate child                                      |
+| `children`      | `ReactNode`                    |                                       | Child elements                                                             |
+| `className`     | `string`                       |                                       | Class name                                                                 |
+| `style`         | `CSSProperties`                |                                       | Style object                                                               |
 
 ### Splitter `(ResplitSplitterProps)`
 
@@ -152,7 +154,7 @@ Specify the size of each pane as a fractional unit (fr). The number of values sh
 setPaneSize(['0.6fr', '0.4fr']);
 ```
 
-#### getPaneCollapsed `(order: number) => boolean`
+#### isPaneCollapsed `(order: number) => boolean`
 
 Get the collapsed state of a pane.
 
@@ -162,12 +164,46 @@ Get the collapsed state of a pane.
 import { Resplit, useResplitContext } from 'react-resplit';
 
 function App() {
-  const { getPaneCollapsed } = useResplitContext({
+  const { isPaneCollapsed } = useResplitContext({
     direction: 'horizontal',
   });
 
   const handleResize = () => {
-    if (getPaneCollapsed(2)) {
+    if (isPaneCollapsed(2)) {
+      // Do something
+    }
+  };
+
+  return (
+    <Resplit.Root>
+      <Resplit.Pane order={0} initialSize="0.5fr">
+        Pane 1
+      </Resplit.Pane>
+      <Resplit.Splitter order={1} size="10px" />
+      <Resplit.Pane order={2} initialSize="0.5fr" onResize={handleResize}>
+        Pane 2
+      </Resplit.Pane>
+    </Resplit.Root>
+  );
+}
+```
+
+#### isPaneMinSize `(order: number) => boolean`
+
+Get the min size state of a pane.
+
+**Note**: The returned value will not update on every render and should be used in a callback e.g. used in combination with a pane's `onResize` callback.
+
+```tsx
+import { Resplit, useResplitContext } from 'react-resplit';
+
+function App() {
+  const { isPaneMinSize } = useResplitContext({
+    direction: 'horizontal',
+  });
+
+  const handleResize = () => {
+    if (isPaneMinSize(2)) {
       // Do something
     }
   };

--- a/lib/Pane.tsx
+++ b/lib/Pane.tsx
@@ -2,7 +2,7 @@ import { ReactNode, HTMLAttributes, forwardRef } from 'react';
 import { Slot } from '@radix-ui/react-slot';
 
 import { useRootContext } from './RootContext';
-import { PANE_DEFAULT_MIN_SIZE } from './const';
+import { PANE_DEFAULT_COLLAPSED_SIZE, PANE_DEFAULT_MIN_SIZE } from './const';
 import { useIsomorphicLayoutEffect } from './utils';
 
 import type { FrValue, Order, PxValue } from './types';
@@ -17,13 +17,29 @@ export type ResplitPaneOptions = {
    */
   initialSize?: FrValue;
   /**
-   * Set the minimum size of the pane as a fractional unit (fr).
+   * Set the minimum size of the pane as a pixel unit (px) or fractional unit (fr).
    *
    * @example '0.1fr'
    *
    * @defaultValue '0fr'
    */
   minSize?: PxValue | FrValue;
+  /**
+   * Whether the pane can be collapsed below its minimum size.
+   *
+   * The pane will be collapsed if the user drags the splitter past 50% of the minimum size.
+   *
+   * @defaultValue false
+   */
+  collapsible?: boolean;
+  /**
+   * Set the collapsed size of the pane as a pixel unit (px) or fractional unit (fr).
+   *
+   * @example '50px'
+   *
+   * @defaultValue '0fr'
+   */
+  collapsedSize?: PxValue | FrValue;
   /**
    * Callback function that is called when the pane starts being resized.
    */
@@ -87,6 +103,8 @@ export const ResplitPane = forwardRef<HTMLDivElement, ResplitPaneProps>(function
     children,
     order,
     minSize = PANE_DEFAULT_MIN_SIZE,
+    collapsible = false,
+    collapsedSize = PANE_DEFAULT_COLLAPSED_SIZE,
     initialSize,
     asChild = false,
     onResize,
@@ -103,6 +121,8 @@ export const ResplitPane = forwardRef<HTMLDivElement, ResplitPaneProps>(function
     registerPane(String(order), {
       minSize,
       initialSize,
+      collapsedSize,
+      collapsible,
       onResize,
       onResizeStart,
       onResizeEnd,
@@ -113,7 +133,8 @@ export const ResplitPane = forwardRef<HTMLDivElement, ResplitPaneProps>(function
     <Comp
       id={`resplit-${id}-${order}`}
       data-resplit-order={order}
-      data-resplit-collapsed={false}
+      data-resplit-is-min={false}
+      data-resplit-is-collapsed={false}
       ref={ref}
       {...rest}
     >

--- a/lib/ResplitContext.tsx
+++ b/lib/ResplitContext.tsx
@@ -13,13 +13,21 @@ export type ResplitContextValue = {
    */
   setPaneSizes: (paneSizes: FrValue[]) => void;
   /**
+   * Get the min size state of a pane.
+   *
+   * @param order - The order of the pane. {@link Order}
+   *
+   * @returns A boolean indicating if the pane is at its min size or not.
+   */
+  isPaneMinSize: (order: number) => boolean;
+  /**
    * Get the collapsed state of a pane.
    *
    * @param order - The order of the pane. {@link Order}
    *
    * @returns A boolean indicating if the pane is collapsed or not.
    */
-  getPaneCollapsed: (order: number) => boolean;
+  isPaneCollapsed: (order: number) => boolean;
 };
 
 export const ResplitContext = createContext<ResplitContextValue | undefined>(undefined);

--- a/lib/Root.tsx
+++ b/lib/Root.tsx
@@ -6,7 +6,6 @@ import { RootContext } from './RootContext';
 import { CURSOR_BY_DIRECTION, GRID_TEMPLATE_BY_DIRECTION } from './const';
 import {
   convertFrToNumber,
-  convertPxToFr,
   convertPxToNumber,
   convertSizeToFr,
   isPx,
@@ -138,13 +137,13 @@ export const ResplitRoot = forwardRef<HTMLDivElement, ResplitRootProps>(function
   const isPaneMinSize = (order: Order) =>
     getChildElement(order)?.getAttribute('data-resplit-is-min') === 'true';
 
-  const setisPaneMinSize = (order: Order, value: boolean) =>
+  const setIsPaneMinSize = (order: Order, value: boolean) =>
     getChildElement(order)?.setAttribute('data-resplit-is-min', String(value));
 
   const isPaneCollapsed = (order: Order) =>
     getChildElement(order)?.getAttribute('data-resplit-is-collapsed') === 'true';
 
-  const setisPaneCollapsed = (order: Order, value: boolean) =>
+  const setIsPaneCollapsed = (order: Order, value: boolean) =>
     getChildElement(order)?.setAttribute('data-resplit-is-collapsed', String(value));
 
   const getRootSize = () =>
@@ -231,13 +230,13 @@ export const ResplitRoot = forwardRef<HTMLDivElement, ResplitRootProps>(function
     }
 
     setChildSize(prevPaneIndex, `${prevPaneSize}fr`);
-    setisPaneMinSize(prevPaneIndex, prevPaneisPaneMinSize);
-    setisPaneCollapsed(prevPaneIndex, prevPaneisPaneCollapsed);
+    setIsPaneMinSize(prevPaneIndex, prevPaneisPaneMinSize);
+    setIsPaneCollapsed(prevPaneIndex, prevPaneisPaneCollapsed);
     prevPane?.onResize?.(`${prevPaneSize}fr`);
 
     setChildSize(nextPaneIndex, `${nextPaneSize}fr`);
-    setisPaneMinSize(nextPaneIndex, nextPaneisPaneMinSize);
-    setisPaneCollapsed(nextPaneIndex, nextPaneisPaneCollapsed);
+    setIsPaneMinSize(nextPaneIndex, nextPaneisPaneMinSize);
+    setIsPaneCollapsed(nextPaneIndex, nextPaneisPaneCollapsed);
     nextPane?.onResize?.(`${nextPaneSize}fr`);
   };
 
@@ -400,8 +399,8 @@ export const ResplitRoot = forwardRef<HTMLDivElement, ResplitRootProps>(function
     paneSizes.forEach((paneSize, index) => {
       const order = index * 2;
       setChildSize(order, paneSize);
-      setisPaneMinSize(order, (children[order] as PaneChild).minSize === paneSize);
-      setisPaneCollapsed(order, (children[order] as PaneChild).collapsedSize === paneSize);
+      setIsPaneMinSize(order, (children[order] as PaneChild).minSize === paneSize);
+      setIsPaneCollapsed(order, (children[order] as PaneChild).collapsedSize === paneSize);
     });
   };
 
@@ -413,17 +412,15 @@ export const ResplitRoot = forwardRef<HTMLDivElement, ResplitRootProps>(function
   useIsomorphicLayoutEffect(() => {
     const paneCount = Object.values(children).filter((child) => child.type === 'pane').length;
 
-    Object.keys(children).forEach((order) => {
-      const orderAsNumber = Number(order);
-      const child = children[orderAsNumber];
+    Object.keys(children).forEach((key) => {
+      const order = Number(key);
+      const child = children[order];
 
       if (child.type === 'pane') {
-        const paneSize = isPaneMinSize(orderAsNumber)
-          ? '0fr'
-          : child.initialSize || `${1 / paneCount}fr`;
-        setChildSize(orderAsNumber, paneSize);
+        const paneSize = isPaneMinSize(order) ? '0fr' : child.initialSize || `${1 / paneCount}fr`;
+        setChildSize(order, paneSize);
       } else {
-        setChildSize(orderAsNumber, child.size);
+        setChildSize(order, child.size);
       }
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/lib/Root.tsx
+++ b/lib/Root.tsx
@@ -194,12 +194,12 @@ export const ResplitRoot = forwardRef<HTMLDivElement, ResplitRootProps>(function
     let prevPaneSize = getChildSizeAsNumber(prevPaneIndex) + delta;
     const prevPaneMinSize = convertFrToNumber(convertSizeToFr(prevPane.minSize, rootSize));
     const prevPaneIsMinSize = prevPaneSize <= prevPaneMinSize;
-    const prevPaneIsCollapsed = prevPaneSize <= prevPaneMinSize / 2;
+    const prevPaneIsCollapsed = prevPane.collapsible && prevPaneSize <= prevPaneMinSize / 2;
 
     let nextPaneSize = getChildSizeAsNumber(nextPaneIndex) - delta;
     const nextPaneMinSize = convertFrToNumber(convertSizeToFr(nextPane.minSize, rootSize));
     const nextPaneIsMinSize = nextPaneSize <= nextPaneMinSize;
-    const nextPaneIsCollapsed = nextPaneSize <= nextPaneMinSize / 2;
+    const nextPaneIsCollapsed = nextPane.collapsible && nextPaneSize <= nextPaneMinSize / 2;
 
     if (prevPaneIsCollapsed || nextPaneIsCollapsed) {
       if (prevPaneIsCollapsed) {

--- a/lib/const.ts
+++ b/lib/const.ts
@@ -17,3 +17,5 @@ export const CURSOR_BY_DIRECTION = {
 export const SPLITTER_DEFAULT_SIZE = '10px';
 
 export const PANE_DEFAULT_MIN_SIZE = '0fr';
+
+export const PANE_DEFAULT_COLLAPSED_SIZE = '0fr';

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,11 +5,13 @@ export const convertFrToNumber = (val: FrValue) => Number(val.replace('fr', ''))
 
 export const convertPxToNumber = (val: PxValue) => Number(val.replace('px', ''));
 
-export const convertPxToFr = (px: number, containerSize: number): FrValue => {
-  return `${px / containerSize}fr`;
-};
+export const convertPxToFr = (px: number, containerSize: number): FrValue =>
+  `${px / containerSize}fr`;
 
 export const isPx = (val: FrValue | PxValue): val is PxValue => val.includes('px');
+
+export const convertSizeToFr = (size: FrValue | PxValue, rootSize: number) =>
+  isPx(size) ? convertPxToFr(convertPxToNumber(size), rootSize) : size;
 
 export const useIsomorphicLayoutEffect =
   typeof window === 'undefined' ? useEffect : useLayoutEffect;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "size-limit": [
     {
-      "limit": "3 kB",
+      "limit": "5 kB",
       "path": "dist/resplit.es.js"
     }
   ],

--- a/src/examples/CodeEditor.tsx
+++ b/src/examples/CodeEditor.tsx
@@ -71,15 +71,15 @@ const PaneHeader = ({ children, id }: { children: React.ReactNode; id?: string }
 );
 
 const ProblemsPane = () => {
-  const { getPaneCollapsed, setPaneSizes } = useResplitContext();
+  const { isPaneMinSize, setPaneSizes } = useResplitContext();
   const [tab, setTab] = React.useState<'console' | 'problems'>('console');
-  const [collapsed, setCollapsed] = useState(false);
+  const [isMinSize, setIsMinSize] = useState(false);
 
   const handleResize = () => {
-    if (getPaneCollapsed(2)) {
-      setCollapsed(true);
+    if (isPaneMinSize(2)) {
+      setIsMinSize(true);
     } else {
-      setCollapsed(false);
+      setIsMinSize(false);
     }
   };
 
@@ -103,14 +103,14 @@ const ProblemsPane = () => {
           </button>
           <button
             className={`flex items-center justify-center h-6 w-6 ml-auto hover:bg-zinc-700 ${
-              collapsed ? 'transform rotate-180' : ''
+              isMinSize ? 'transform rotate-180' : ''
             }`}
             onMouseDown={(e) => {
               e.stopPropagation();
             }}
             onClick={() => {
-              setPaneSizes(collapsed ? ['0.4fr', '0.6fr'] : ['1fr', '0fr']);
-              setCollapsed(!collapsed);
+              setPaneSizes(isMinSize ? ['0.4fr', '0.6fr'] : ['1fr', '0fr']);
+              setIsMinSize(!isMinSize);
             }}
           >
             <svg

--- a/src/examples/CodeEditor.tsx
+++ b/src/examples/CodeEditor.tsx
@@ -191,7 +191,14 @@ export const CodeEditorExample = () => {
           </button>
         </div>
         <Resplit.Root className="flex-1 font-mono text-sm">
-          <Resplit.Pane order={0} initialSize="0.15fr" minSize="0.1fr" className="bg-zinc-800">
+          <Resplit.Pane
+            order={0}
+            initialSize="0.15fr"
+            minSize="0.1fr"
+            collapsedSize="40px"
+            collapsible
+            className="bg-zinc-800 overflow-hidden"
+          >
             <PaneHeader id="files-pane">Files</PaneHeader>
             <SandpackFileExplorer autoHiddenFiles className="py-0" />
           </Resplit.Pane>


### PR DESCRIPTION
Previously, a pane at its minimum size was considered "collapsed". In this PR, this concept is separated into two configurable states for a pane:
- `minSize` - when a pane reaches its minimum size.
- `collapsedSize` - when resizing extends 50% over the panes minimum size, it collapses.

Two functions are available via resplit context:
- `isPaneMinSize` - check if a pane is at its min size or not.
- `isPaneCollapsed` - check if a pane is collapsed or not.


https://github.com/KenanYusuf/react-resplit/assets/9557798/a9e40870-2c14-4585-bba5-5f6b777afb85

