### PR TITLE
Add types to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "exports": {
     ".": {
       "import": "./dist/resplit.es.js",
-      "require": "./dist/resplit.umd.cjs"
+      "require": "./dist/resplit.umd.cjs",
+      "types": "./dist/resplit.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
Hi, thanks for `react-resplit`, I enjoyed using for [play.rimu.dev](https://play.rimu.dev/?i=bNcpBCoAgFATQqwweQ3DXohtE4EbxV8LPD31bdPs0aTMD88acpBp2sr4ATLUXcIokC2-Uriy3etPnXAbm7XM41x-Z-RkO1INK29YQY8A0UuRXYqWmMzELFrk4dTEv) and plan to use again in another project. :purple_heart: 

For some reason, I get an error where the TypeScript typings are not found. This patch seems to fix that. :shrug: 